### PR TITLE
update azurerm resource and the function `interpolated`

### DIFF
--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -173,12 +173,7 @@ class _base(object):
     @property
     def interpolated(self):
         """The object in interpolated syntax: ``${...}``."""
-        if self._class == 'variable':
-            return '${{{}}}'.format(self.fullname)
-        elif self._class == 'resources':
-            return '${{{}}'.format(self._fullname)
-        else:
-            return '${{{}}'.format(self._fullname)
+        return '${{{}}}'.format(self.fullname)
 
     @property
     def fullname(self):

--- a/terrascript/azurerm/r.py
+++ b/terrascript/azurerm/r.py
@@ -269,3 +269,5 @@ virtual_network = azurerm_virtual_network
 class azurerm_virtual_network_peering(_resource): pass
 virtual_network_peering = azurerm_virtual_network_peering
 
+class azurerm_virtual_machine_data_disk_attachment(_resource): pass
+virtual_machine_data_disk_attachment = azurerm_virtual_machine_data_disk_attachment


### PR DESCRIPTION
Thanks for your perfect python-terrascript! But I have found some bugs during using it. 
First, we use the resource 'azurerm_virtual_machine_data_disk_attachment' but the source code doesn't contain it and I add it. 
Second, when generating the output, I need to add the parameter 'depends_on' like this:     
"bastion-host": {
      "depends_on": ["${openstack_compute_instance_v2.bastion_1}"]
      "value": ["${openstack_compute_instance_v2.bastion_1.name}"]
    }
But I find that function 'interpolated' cannot generate '${openstack_compute_instance_v2.bastion_1}' and  raise error due to missing one close curly brace. So i change it and it works. Am I right?