### PR TITLE
Changes methods 'init__' to '__init__' and PEP8 in tests

### DIFF
--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -215,6 +215,7 @@ class Terrascript(dict):
         """Add to the configuration using the ``+`` syntax."""
 
         self += object
+        return object
 
 
 class Resource(Block):

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -141,7 +141,6 @@ class Terrascript(dict):
         for object in objects:
             self += object
 
-
     def __str__(self):
         return json.dumps(self, indent=INDENT)
 
@@ -332,70 +331,81 @@ class Function(Block):
 # Lower case classes for backwards will be deprecated in the future(???)
 
 class module(Module):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class data(Data):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class resource(Resource):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class variable(Variable):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class provider(Provider):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class output(Output):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class provisioner(Provisioner):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class connection(Connection):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class backend(Backend):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 class terraform(Terraform):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
 
+
 class function(Function):
-    def   init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         warnings.warn("'{}' will be deprecated in the future, please use '{}' instead".format(
             self.__class__.__name__, self.__class__.__name__.title()), PendingDeprecationWarning)
         super().__init__(*args, **kwargs)
+
 
 # THREE_TIER_ITEMS = ['data', 'resource', 'provider']
 # TWO_TIER_ITEMS = ['variable', 'module', 'output', 'provisioner']

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -1,34 +1,44 @@
 """Functions shared by all test modules."""
 
+import deepdiff
 import json
 import os
-import deepdiff
+import sys
+
+
+if sys.version_info >= (3, 5):
+    # JSONDecodeError was introduced in python 3.5
+    # https://docs.python.org/3/library/json.html#json.JSONDecodeError
+    JSONDecodeError = json.decoder.JSONDecodeError
+else:
+    JSONDecodeError = ValueError
+
 
 def assert_deep_equal(t1, t2):
-    """Compare ``t1`` with the JSON structure parsed from ``path``. 
+    """Compare ``t1`` with the JSON structure parsed from ``path``.
 
        Comparison is performed through the DeepDiff Python package
        (https://github.com/seperman/deepdiff).
-       
+
        The ``diffs`` variable will contain any differences which
        can be displayed in the debugger.
-       
+
            (Pdb) pp(diffs)
 
     """
-    
+
     t1 = json.loads(str(t1))
-    
+
     try:
         t2 = json.loads(t2)
-    except json.decoder.JSONDecodeError:
+    except JSONDecodeError:
         with open(os.path.join('tests', 'configs', t2), 'rt') as fp:
             t2 = json.load(fp)
-        
+
     diffs = deepdiff.DeepDiff(t1, t2)
-    
+
     assert diffs == {}
-        
-    
+
+
 # For tests where the call has not been renamed yet.
 assert_equals_json = assert_deep_equal

--- a/tests/test_001.py
+++ b/tests/test_001.py
@@ -3,9 +3,10 @@
 
 from shared import assert_deep_equal
 
+
 def test():
     """Resource (001)"""
-    
+
     import terrascript
     import terrascript.provider
     import terrascript.resource

--- a/tests/test_002.py
+++ b/tests/test_002.py
@@ -6,6 +6,7 @@ import terrascript.resource
 
 from shared import assert_equals_json
 
+
 def test():
     """Provider Endpoints (002)
 

--- a/tests/test_003.py
+++ b/tests/test_003.py
@@ -3,6 +3,7 @@ import terrascript.provider
 
 from shared import assert_equals_json
 
+
 def test():
     """Module (003)"""
 

--- a/tests/test_004.py
+++ b/tests/test_004.py
@@ -4,12 +4,14 @@ import terrascript
 
 from shared import assert_equals_json
 
+
 def test():
     """Variable (004)"""
 
     config = terrascript.Terrascript()
 
     config += terrascript.Variable('image_id', type='string')
-    config += terrascript.Variable('availability_zone_names', type='list(string)', default=["us-west-1a"])
+    config += terrascript.Variable('availability_zone_names',
+                                   type='list(string)', default=["us-west-1a"])
 
     assert_equals_json(config, 'test_004.tf.json')

--- a/tests/test_005.py
+++ b/tests/test_005.py
@@ -6,36 +6,36 @@ import terrascript.resource
 
 from shared import assert_equals_json
 
+
 def test():
     """Provisioner (005)"""
 
     config = terrascript.Terrascript()
-    
+
     config += terrascript.provider.aws(version='~> 2.0', region='us-east-1')
-    
+
     #  Copies the myapp.conf file to /etc/myapp.conf
-    provisioner1 = terrascript.Provisioner('file', source='conf/myapp.conf', 
-                                           destination = '/etc/myapp.conf')
-    
+    provisioner1 = terrascript.Provisioner('file', source='conf/myapp.conf',
+                                           destination='/etc/myapp.conf')
+
     # Copies the string in content into /tmp/file.log
-    provisioner2 = terrascript.Provisioner('file', source='ami used: ${self.ami}', 
-                                           destination = '/tmp/file.log')
-    
+    provisioner2 = terrascript.Provisioner('file', source='ami used: ${self.ami}',
+                                           destination='/tmp/file.log')
+
     # Copies the configs.d folder to /etc/configs.d
-    provisioner3 = terrascript.Provisioner('file', source='conf/configs.d', 
-                                           destination = '/etc')
-    
+    provisioner3 = terrascript.Provisioner('file', source='conf/configs.d',
+                                           destination='/etc')
+
     # Copies all files and folders in apps/app1 to D:/IIS/webapp1
-    provisioner4 = terrascript.Provisioner('file', source='apps/app1/', 
-                                           destination = 'D:/IIS/webapp1')
-    
-    
+    provisioner4 = terrascript.Provisioner('file', source='apps/app1/',
+                                           destination='D:/IIS/webapp1')
+
     config += terrascript.resource.aws_instance('web',
-                                                ami = "AMI",
+                                                ami="AMI",
                                                 instance_type="t2.micro",
-                                                provisioner=[provisioner1, 
-                                                             provisioner2, 
-                                                             provisioner3, 
+                                                provisioner=[provisioner1,
+                                                             provisioner2,
+                                                             provisioner3,
                                                              provisioner4])
-    
+
     assert_equals_json(config, 'test_005.tf.json')

--- a/tests/test_006.py
+++ b/tests/test_006.py
@@ -6,6 +6,7 @@ import terrascript.resource
 
 from shared import assert_equals_json
 
+
 def test():
     """Output (006)"""
 
@@ -13,9 +14,11 @@ def test():
 
     config += terrascript.provider.aws(version='~> 2.0', region='us-east-1')
 
-    aws_instance = terrascript.resource.aws_instance('web', ami = "AMI", instance_type="t2.micro")
+    aws_instance = terrascript.resource.aws_instance(
+        'web', ami="AMI", instance_type="t2.micro")
     config += aws_instance
 
-    config += terrascript.Output('instance_ip_addr', value=aws_instance.server.private_ip)
+    config += terrascript.Output('instance_ip_addr',
+                                 value=aws_instance.server.private_ip)
 
     assert_equals_json(config, 'test_006.tf.json')

--- a/tests/test_007.py
+++ b/tests/test_007.py
@@ -6,6 +6,7 @@ import terrascript.resource
 
 from shared import assert_equals_json
 
+
 def test():
     """Locals (007)"""
 
@@ -13,15 +14,21 @@ def test():
 
     config += terrascript.provider.aws(version='~> 2.0', region='us-east-1')
 
-    blue = terrascript.resource.aws_instance('blue', ami = "AMI", instance_type="t2.micro")
+    blue = terrascript.resource.aws_instance(
+        'blue', ami="AMI", instance_type="t2.micro")
     config += blue
 
-    green = terrascript.resource.aws_instance('green', ami = "AMI", instance_type="t2.micro")
+    green = terrascript.resource.aws_instance(
+        'green', ami="AMI", instance_type="t2.micro")
     config += green
 
     locals1 = terrascript.Locals(service_name='forum', owner='Community Team')
     config += locals1
 
-    config += terrascript.Locals(instance_ids='concat(aws_instance.blue.*.id, aws_instance.green.*.id)')
+    config += terrascript.Locals(
+        instance_ids='concat(aws_instance.blue.*.id, aws_instance.green.*.id)')
 
-    config += terrascript.Locals(Service=locals1.service_name, Owner=locals1.owner)
+    config += terrascript.Locals(Service=locals1.service_name,
+                                 Owner=locals1.owner)
+
+    assert_equals_json(config, 'test_007.tf.json')

--- a/tests/test_008.py
+++ b/tests/test_008.py
@@ -6,6 +6,7 @@ import terrascript.data
 
 from shared import assert_equals_json
 
+
 def test():
     """Data (008)"""
 
@@ -14,6 +15,6 @@ def test():
     config += terrascript.provider.aws(version='~> 2.0', region='us-east-1')
 
     config += terrascript.data.aws_ami('example', most_recent=True, owners=['self'],
-                                        tags=dict(Name="app-server", Tested="true"))
+                                       tags=dict(Name="app-server", Tested="true"))
 
     assert_equals_json(config, 'test_008.tf.json')

--- a/tests/test_TUAR_hello_world.py
+++ b/tests/test_TUAR_hello_world.py
@@ -27,9 +27,10 @@ def test():
     import terrascript
     import terrascript.provider
     import terrascript.resource
-    
+
     config = terrascript.Terrascript()
     config += terrascript.provider.aws(region='us-east-2', version='~>2.0')
-    config += terrascript.resource.aws_instance('example', ami='ami-0c55b159cbfafe1f0', instance_type='t2.micro')
-    
+    config += terrascript.resource.aws_instance(
+        'example', ami='ami-0c55b159cbfafe1f0', instance_type='t2.micro')
+
     shared.assert_deep_equal(config, 'test_TUAR_hello_world.tf.json')

--- a/tests/test_TUAR_why_terraform.py
+++ b/tests/test_TUAR_why_terraform.py
@@ -33,18 +33,18 @@ def test():
     import terrascript
     import terrascript.provider
     import terrascript.resource
-    
+
     USER_DATA = "#!/bin/bash\nsudo service apache2 start"
-    
+
     config = terrascript.Terrascript()
-    
-    config += terrascript.provider.aws(region='us-east-2', 
+
+    config += terrascript.provider.aws(region='us-east-2',
                                        version='~>2.0')
-    
-    config += terrascript.resource.aws_instance('app', 
+
+    config += terrascript.resource.aws_instance('app',
                                                 instance_type='t2.micro',
                                                 availability_zone='us-east-2a',
                                                 ami='ami-0c55b159cbfafe1f0',
                                                 user_data=USER_DATA)
-    
+
     shared.assert_deep_equal(config, 'test_TUAR_why_terraform.tf.json')

--- a/tests/test_issue63.py
+++ b/tests/test_issue63.py
@@ -6,6 +6,7 @@ import terrascript.oci
 
 from shared import assert_equals_json
 
+
 def test():
     """Issue #63 - Add support for OCI provider
 


### PR DESCRIPTION
Fix typo error. Changes methods 'init__' to '__init__'.