### PR TITLE
Updated documentation link to avoid 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.1] - Not yet released
+### Changed
+* Contributors are now sorted in alphabetical order
+* Documentation link from readme now points toward develop build on readthedocs.io to avoid 404
+
 ## [0.9.0] - Not yet released
 ### Deprecated
 * Individual modules for each provider (Example: ``terrascript.aws.r``) are now deprecated in favour of

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,21 +3,22 @@
 List of contributors (bug reports, fixes, suggestions, anything) to
 **python-terrascript** in no particular order.
 
-* Vianney Foucault
-* Josh Smift
-* Robin Bowes
-* Nielson Santana
 * Austin Millan
-* LaurensV
-* Niranjan Bommu
-* Sergey Puzirev
-* Yuri Leunguu
-* Joao Gilberto Magalhaes
-* Kumaresh
-* leosanchez16
-* Ryan Walder
-* Maor Friedman
 * DJDavisson
+* ilons
+* Joao Gilberto Magalhaes
+* Josh Smift
+* Kumaresh
+* LaurensV
+* leosanchez16
+* Maor Friedman
+* Nielson Santana
+* Niranjan Bommu
+* Robin Bowes
+* Ryan Walder
+* Sergey Puzirev
+* Vianney Foucault
+* Yuri Leunguu
 
 Did I miss anyone?
 

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ Links
 * `Community Chat`_ on Zulip.
 * `Terraform JSON`_ syntax.
 
-.. _Documentation: https://python-terrascript.readthedocs.io/en/index.html
+.. _Documentation: https://python-terrascript.readthedocs.io/en/develop/
 .. _Github: https://github.com/mjuenema/python-terrascript
 .. _`Terraform JSON`: https://www.terraform.io/docs/configuration/syntax-json.html
 .. _`Community Chat`: https://python-terrascript.zulipchat.com/


### PR DESCRIPTION
## [0.9.1] - Not yet released
### Changed
* Contributors are now sorted in alphabetical order
* Documentation link from readme now points toward develop build on readthedocs.io to avoid 404