### PR TITLE
Should insert var.name during variable string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 * Created ``terrascript.Terrascript.__iter__()`` method for iterating over resources, data sources, etc.  (issue #98).
 ### Fixed
-* String interpolation of variable should now properly result in a var.name reference (issue #112)
+* String interpolation of variable should now properly result in a var.name reference (issue #109)
 * Re-introduced ``terrascript.Terrascript.update()`` method (issue #98).
 ### Changed
 * All Python code is now automatically formatted using [Black](https://pypi.org/project/black/).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- String interpolation of variable should now properly result in a var.name reference
+
 ## [0.9.1] - Not yet released
 ### Changed
 * Contributors are now sorted in alphabetical order

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -333,7 +333,8 @@ class Provider(Block):
 
 
 class Variable(NamedBlock):
-    pass
+    def __repr__(self):
+        return f'var.{self._name}'
 
 
 class Module(NamedBlock):

--- a/tests/test_basic_variable.py
+++ b/tests/test_basic_variable.py
@@ -43,6 +43,11 @@ class TestVariable(object):
         assert self.cfg["variable"]["name"]["type"] == "string"
         assert self.cfg["variable"]["name"]["default"] == "You"
 
-    def test_reference_variable(self):
-        # TODO
-        pass
+    def test_string_interpolation(self):
+        var = terrascript.Variable("myvar", type="string", default="myval")
+
+        string_var = str(var)
+        assert string_var == "var.myvar", "String interpolation of variable did not return its reference"
+
+        embeded_var = "embeded-${{{}}}".format(var)
+        assert embeded_var == "embeded-${var.myvar}", "Formatting a string with variable did not insert reference"


### PR DESCRIPTION
### Fixed
- String interpolation of variable should now properly result in a var.name reference