### PR TITLE
Use backwards compatible syntax

### DIFF
--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -330,7 +330,7 @@ class Provider(Block):
 
 class Variable(NamedBlock):
     def __repr__(self):
-        return f"var.{self._name}"
+        return "var.{}".format(self._name)
 
 
 class Module(NamedBlock):

--- a/tests/test_basic_variable.py
+++ b/tests/test_basic_variable.py
@@ -47,7 +47,11 @@ class TestVariable(object):
         var = terrascript.Variable("myvar", type="string", default="myval")
 
         string_var = str(var)
-        assert string_var == "var.myvar", "String interpolation of variable did not return its reference"
+        assert (
+            string_var == "var.myvar"
+        ), "String interpolation of variable did not return its reference"
 
         embeded_var = "embeded-${{{}}}".format(var)
-        assert embeded_var == "embeded-${var.myvar}", "Formatting a string with variable did not insert reference"
+        assert (
+            embeded_var == "embeded-${var.myvar}"
+        ), "Formatting a string with variable did not insert reference"


### PR DESCRIPTION
### Changed
* Now uses old format-style string interpolation to be compatible with python < 3.6