### PR TITLE
Issue 109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 * Code for providers updated to conform with black
 * Contributors are now sorted in alphabetical order
 * Documentation link from readme now points toward develop build on readthedocs.io to avoid 404
+* Documentation on variable usage updated to reflect changes in issue #109
 * Requirements files are now sorted alphabetically and duplicate entries are removed
 - Updated code for providers generated
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 * Contributors are now sorted in alphabetical order
 * Documentation link from readme now points toward develop build on readthedocs.io to avoid 404
 * Documentation on variable usage updated to reflect changes in issue #109
+* Makefiles cleaned up, and help target contents now dynamically generated from comments
 * Requirements files are now sorted alphabetically and duplicate entries are removed
 * Updated code for providers generated
 ### Deleted

--- a/docs/examples/tutorial_output1/tutorial_output1.tf.json
+++ b/docs/examples/tutorial_output1/tutorial_output1.tf.json
@@ -15,13 +15,13 @@
     "aws_instance": {
       "example": {
         "instance_type": "t2.micro",
-        "ami": "var.image_id"
+        "ami": "${var.image_id}"
       }
     }
   },
   "output": {
     "instance_ip_addr": {
-      "value": "aws_instance.example.private_ip",
+      "value": "${aws_instance.example.private_ip}",
       "description": "The private IP address of the instance."
     }
   }

--- a/docs/examples/tutorial_variable1/tutorial_variable1.tf.json
+++ b/docs/examples/tutorial_variable1/tutorial_variable1.tf.json
@@ -15,7 +15,7 @@
     "aws_instance": {
       "example": {
         "instance_type": "t2.micro",
-        "ami": "var.image_id"
+        "ami": "${var.image_id}"
       }
     }
   }

--- a/docs/json.rst
+++ b/docs/json.rst
@@ -98,6 +98,30 @@ Example:
      }
    }
 
+Variable references
+~~~~~~~~~~~~~~~~~~~
+
+When using a variable as a attribute value for a object, a reference are used.
+
+Example:
+* Variable ``image_id`` are used as name for instance.
+.. code-block:: json
+
+   {
+     "variable": {
+       "image_id": {
+         "type": "string"
+       }
+     },
+     "resource": {
+       "aws_instance": {
+         "instance1": {
+           "instance_type": "${var.image_id}"
+         }
+       }
+     }
+   }
+
 Output Values
 ~~~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -102,7 +102,7 @@ variable into the correct Terraform JSON syntax.
 **JSON**
 
 In the output the reference to the ``image_id`` has been converted from a reference to a 
-Python variable ``ami=v`` to the correct Terraform JSON syntax of ``var.image_id``. 
+Python variable ``ami=v`` to the correct Terraform JSON syntax of ``${var.image_id}``.
 
 .. literalinclude:: examples/tutorial_variable1/tutorial_variable1.tf.json
    :emphasize-lines: 18

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -330,7 +330,7 @@ class Provider(Block):
 
 class Variable(NamedBlock):
     def __repr__(self):
-        return "var.{}".format(self._name)
+        return "${{var.{}}}".format(self._name)
 
 
 class Module(NamedBlock):

--- a/tests/test_basic_variable.py
+++ b/tests/test_basic_variable.py
@@ -46,12 +46,15 @@ class TestVariable(object):
     def test_string_interpolation(self):
         var = terrascript.Variable("myvar", type="string", default="myval")
 
-        string_var = str(var)
-        assert (
-            string_var == "var.myvar"
+        expected_value = "${var.myvar}"
+        assert expected_value == str(
+            var
         ), "String interpolation of variable did not return its reference"
+        assert expected_value == repr(
+            var
+        ), "String representation of variable did not return its reference"
 
-        embeded_var = "embeded-${{{}}}".format(var)
-        assert (
-            embeded_var == "embeded-${var.myvar}"
+        expected_value = "embeded-${var.myvar}"
+        assert expected_value == "embeded-{}".format(
+            var
         ), "Formatting a string with variable did not insert reference"


### PR DESCRIPTION
Sorry for taking this another round, but here goes:
### Fixed
* Variable references are now inserted as `${var.name}` instead of only `var.name`
### Changed
* Documentation on variable usage updated to reflect changes in issue #109