### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ DEFAULT_GOAL: help
 	test_issues \
 	test_docs
 
-black: clean ## Format Python code with black to keep style consistent
-	black -t py35 .
+black: clean ## Format Python code with Black to keep style consistent
+	black -t py36 .
 
 clean: ## Cleanup temporary / cached files
 	rm -f tests/*.pyc

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 try:

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -99,9 +99,7 @@ class Block(dict):
             raise AttributeError
         else:
             if isinstance(self, Resource):
-                return Attribute(
-                    f"{self.__class__.__name__}.{self._name}.{attr}"
-                )
+                return Attribute(f"{self.__class__.__name__}.{self._name}.{attr}")
             if isinstance(self, Module):
                 return Attribute(f"module.{self._name}.{attr}")
             if isinstance(self, Variable):
@@ -110,9 +108,7 @@ class Block(dict):
                 return Attribute(f"local.{attr}")
             elif isinstance(self, Data):
                 # data.google_compute_image.NAME.ATTR
-                return Attribute(
-                    f"data.{self.__class__.__name__}.{self._name}.{attr}"
-                )
+                return Attribute(f"data.{self.__class__.__name__}.{self._name}.{attr}")
             else:
                 raise AttributeError(attr)
 

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -52,7 +52,7 @@ class Attribute(str):
     """
 
     def __getattr__(self, name):
-        return Attribute("{}.{}".format(self, name))
+        return Attribute(f"{self}.{name}")
 
 
 class Block(dict):
@@ -68,7 +68,7 @@ class Block(dict):
         # TODO: Add others?
         for k, v in kwargs.items():
             if isinstance(v, Variable):
-                kwargs[k] = "var.{}".format(v._name)
+                kwargs[k] = f"var.{v._name}"
 
         super().__init__(**kwargs)
 
@@ -100,18 +100,18 @@ class Block(dict):
         else:
             if isinstance(self, Resource):
                 return Attribute(
-                    "{}.{}.{}".format(self.__class__.__name__, self._name, attr)
+                    f"{self.__class__.__name__}.{self._name}.{attr}"
                 )
             if isinstance(self, Module):
-                return Attribute("module.{}.{}".format(self._name, attr))
+                return Attribute(f"module.{self._name}.{attr}")
             if isinstance(self, Variable):
-                return Attribute("var.{}.{}".format(self._name, attr))
+                return Attribute(f"var.{self._name}.{attr}")
             elif isinstance(self, Locals):
-                return Attribute("local.{}".format(attr))
+                return Attribute(f"local.{attr}")
             elif isinstance(self, Data):
                 # data.google_compute_image.NAME.ATTR
                 return Attribute(
-                    "data.{}.{}.{}".format(self.__class__.__name__, self._name, attr)
+                    f"data.{self.__class__.__name__}.{self._name}.{attr}"
                 )
             else:
                 raise AttributeError(attr)
@@ -268,8 +268,7 @@ class Terrascript(dict):
                 for i in res:
                     yield from recurse(i)
 
-        for item in recurse(self):
-            yield item
+        yield from recurse(self)
 
 
 # Top-level blocks ----------------------------------------
@@ -314,7 +313,7 @@ class Provider(Block):
 
 class Variable(NamedBlock):
     def __repr__(self):
-        return "var.{}".format(self._name)
+        return f"var.{self._name}"
 
 
 class Module(NamedBlock):

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -29,26 +29,26 @@ TERRAFORM_KEY = "terraform"
 
 
 class Attribute(str):
-    """ An `Attribute` handles access to not yet known attributes.
+    """An `Attribute` handles access to not yet known attributes.
 
-        This called by `Block.__getattr__` to deal with
+    This called by `Block.__getattr__` to deal with
 
-        In the example below the ``aws_instance`` does not have attributes
-        ``.server`` and in turn ``.server.private_ip``. To prevent Python
-        from raising an `AttributeError` the `Attribute.__getattr__()` method
-        creates a new string by appending the attribute name.
+    In the example below the ``aws_instance`` does not have attributes
+    ``.server`` and in turn ``.server.private_ip``. To prevent Python
+    from raising an `AttributeError` the `Attribute.__getattr__()` method
+    creates a new string by appending the attribute name.
 
-        Python:
+    Python:
 
-            config = terrascript.Terrascript()
-            config += terrascript.aws.aws(version='~> 2.0', region='us-east-1')
-            aws_instance = terrascript.aws.r.aws_instance('web', ...)
-            config += aws_instance
-            config += terrascript.Output('instance_ip_addr',
-                                          value=aws_instance.server.private_ip)
-                                                            ^^^^^^^^^^^^^^^^^^
+        config = terrascript.Terrascript()
+        config += terrascript.aws.aws(version='~> 2.0', region='us-east-1')
+        aws_instance = terrascript.aws.r.aws_instance('web', ...)
+        config += aws_instance
+        config += terrascript.Output('instance_ip_addr',
+                                      value=aws_instance.server.private_ip)
+                                                        ^^^^^^^^^^^^^^^^^^
 
-        JSON:
+    JSON:
     """
 
     def __getattr__(self, name):
@@ -73,23 +73,23 @@ class Block(dict):
         super().__init__(**kwargs)
 
     def __getattr__(self, attr):
-        """ Special handling for accessing attributes,
+        """Special handling for accessing attributes,
 
-            If ``Block.attr`` does not exist, try to return Block[attr]. If that
-            does not exists either, return `attr` as a string, prefixed
-            by the name (and type) of the Block that is referenced.
+        If ``Block.attr`` does not exist, try to return Block[attr]. If that
+        does not exists either, return `attr` as a string, prefixed
+        by the name (and type) of the Block that is referenced.
 
-            This is for example necessary for referencing an attribute of a
-            Terraform resource which only becomes available after the resource
-            has been created.
+        This is for example necessary for referencing an attribute of a
+        Terraform resource which only becomes available after the resource
+        has been created.
 
-            Example:
+        Example:
 
-               instance = terrascript.resources.aws_instance("server", ...)
-               output = terrascript.Output("instance_ip_addr",
-                                           value=instance.private_ip)
-                                                        ^^^^^^^^^^
-            Where ``instance.private_ip`` does not (yet) exist.
+           instance = terrascript.resources.aws_instance("server", ...)
+           output = terrascript.Output("instance_ip_addr",
+                                       value=instance.private_ip)
+                                                    ^^^^^^^^^^
+        Where ``instance.private_ip`` does not (yet) exist.
         """
         # Try to return the entry in the dictionary. Otherwise return a string
         # which must be formatted differently depending on what is referenced.
@@ -121,7 +121,7 @@ class NamedBlock(Block):
 
 
 class NamedSubBlock(Block):
-    """ NamedSubBlocks are similar to NamedBlocks except that the `name`
+    """NamedSubBlocks are similar to NamedBlocks except that the `name`
         is the key to a nested dictionary contain `kwargs`. NamedSubBlocks
         are not added to the top-level Terrascript structure but are
         arguments to another block. The backend argument to a Terraform
@@ -136,7 +136,7 @@ class NamedSubBlock(Block):
 
 
 class Terrascript(dict):
-    """ Top-level container for Terraform configurations.
+    """Top-level container for Terraform configurations.
 
     :param *objects: Optional list of Terrascript data sources, resources,
     """
@@ -283,25 +283,25 @@ class Data(NamedBlock):
 
 
 class Provider(Block):
-    """ Terraform provider
+    """Terraform provider
 
-        HCL:
+    HCL:
 
-            provider "aws" {
-                region = "us-east-1"
-                version = "u~> 2.0"
-            }
+        provider "aws" {
+            region = "us-east-1"
+            version = "u~> 2.0"
+        }
 
-        JSON:
+    JSON:
 
-            "provider": {
-                "aws": [
-                    {
-                        "region": "us-east-1",
-                        "version": "~> 2.0"
-                    }
-                ]
-            }
+        "provider": {
+            "aws": [
+                {
+                    "region": "us-east-1",
+                    "version": "~> 2.0"
+                }
+            ]
+        }
     """
 
     pass
@@ -313,9 +313,9 @@ class Variable(NamedBlock):
 
 
 class Module(NamedBlock):
-    """ Terraform child module call.
+    """Terraform child module call.
 
-        https://www.terraform.io/docs/configuration/modules.html
+    https://www.terraform.io/docs/configuration/modules.html
     """
 
     pass
@@ -329,16 +329,16 @@ class Output(NamedBlock):
 
 
 class Provisioner(dict):
-    """ A provisioner is a nested dictionary.
+    """A provisioner is a nested dictionary.
 
-       The `name` argument must be a valid Terraform provisioner.
+    The `name` argument must be a valid Terraform provisioner.
 
-       >>> import terrascript
-       >>> p = terrascript.Provisioner("local-exec", command="echo 'Hello World'")
-       >>> print(p)
-       {'local-exec': {'command': "echo 'Hello World"}}
-    
-       https://www.terraform.io/docs/provisioners/index.html
+    >>> import terrascript
+    >>> p = terrascript.Provisioner("local-exec", command="echo 'Hello World'")
+    >>> print(p)
+    {'local-exec': {'command': "echo 'Hello World"}}
+
+    https://www.terraform.io/docs/provisioners/index.html
     """
 
     def __init__(self, name, **kwargs):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+black==20.8b1
 coverage==4.4.1
 deepdiff==4.0.7
 nose==1.3.7

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -23,7 +23,7 @@ def assert_deep_equal(t1, t2):
     try:
         t2 = json.loads(t2)
     except json.decoder.JSONDecodeError:
-        with open(os.path.join("tests", "configs", t2), "rt") as fp:
+        with open(os.path.join("tests", "configs", t2)) as fp:
             t2 = json.load(fp)
 
     diffs = deepdiff.DeepDiff(t1, t2)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -6,15 +6,15 @@ import deepdiff
 
 
 def assert_deep_equal(t1, t2):
-    """Compare ``t1`` with the JSON structure parsed from ``path``. 
+    """Compare ``t1`` with the JSON structure parsed from ``path``.
 
-       Comparison is performed through the DeepDiff Python package
-       (https://github.com/seperman/deepdiff).
-       
-       The ``diffs`` variable will contain any differences which
-       can be displayed in the debugger.
-       
-           (Pdb) pp(diffs)
+    Comparison is performed through the DeepDiff Python package
+    (https://github.com/seperman/deepdiff).
+
+    The ``diffs`` variable will contain any differences which
+    can be displayed in the debugger.
+
+        (Pdb) pp(diffs)
 
     """
 

--- a/tests/test_basic_data.py
+++ b/tests/test_basic_data.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.data
 
 
-class TestDatasource(object):
+class TestDatasource:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 

--- a/tests/test_basic_locals.py
+++ b/tests/test_basic_locals.py
@@ -5,7 +5,7 @@ import terrascript.resource
 # *** These test work but terrascript.Locals is not supported. ***
 
 
-class TestLocals(object):
+class TestLocals:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
         self.cfg += terrascript.provider.aws(region="us-east-1")

--- a/tests/test_basic_module.py
+++ b/tests/test_basic_module.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.provider
 
 
-class TestModule(object):
+class TestModule:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 

--- a/tests/test_basic_provider.py
+++ b/tests/test_basic_provider.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.provider
 
 
-class TestProvider(object):
+class TestProvider:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 

--- a/tests/test_basic_provisioner.py
+++ b/tests/test_basic_provisioner.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.resource
 
 
-class TestProvisioner(object):
+class TestProvisioner:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 

--- a/tests/test_basic_resource.py
+++ b/tests/test_basic_resource.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.resource
 
 
-class TestResource(object):
+class TestResource:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 

--- a/tests/test_basic_variable.py
+++ b/tests/test_basic_variable.py
@@ -2,7 +2,7 @@ import terrascript
 import terrascript.provider
 
 
-class TestVariable(object):
+class TestVariable:
     def __init__(self):
         self.cfg = terrascript.Terrascript()
 
@@ -51,7 +51,7 @@ class TestVariable(object):
             string_var == "var.myvar"
         ), "String interpolation of variable did not return its reference"
 
-        embeded_var = "embeded-${{{}}}".format(var)
+        embeded_var = f"embeded-${{{var}}}"
         assert (
             embeded_var == "embeded-${var.myvar}"
         ), "Formatting a string with variable did not insert reference"

--- a/tools/makecode.py
+++ b/tools/makecode.py
@@ -235,7 +235,7 @@ def create_provider(provider, modulesdir):
 
 
 def get_sanitized_name(provider):
-    """ Get the string sanitized for use as python module
+    """Get the string sanitized for use as python module
 
     :return:
     """

--- a/tools/makecode.py
+++ b/tools/makecode.py
@@ -52,7 +52,7 @@ DEBUG = False
 CONCURRENCY = 10
 INPUT = "providers.yml"
 
-REGEX = re.compile(b'"(?P<name>.+)":\s+(?P<type>resource|data)')
+REGEX = re.compile(br'"(?P<name>.+)":\s+(?P<type>resource|data)')
 """REGEX to extract the names of resources and data sources from a provider.go file.
 
     DataSourcesMap: map[string]*schema.Resource{
@@ -209,10 +209,10 @@ def legacy_create_provider_datasources(provider, providerdir, datasources):
 
 
 def legacy_create_provider_resources(provider, providerdir, resources):
-    logging.debug("legacy_create_provider_resources provider={}".format(provider))
-    logging.debug("legacy_create_provider_resources providerdir={}".format(providerdir))
+    logging.debug(f"legacy_create_provider_resources provider={provider}")
+    logging.debug(f"legacy_create_provider_resources providerdir={providerdir}")
     for resource in resources:
-        logging.debug("legacy_create_provider_resources resource={}".format(resource))
+        logging.debug(f"legacy_create_provider_resources resource={resource}")
 
     with open(os.path.join(providerdir, "r.py"), "wt") as fp:
         fp.write(
@@ -229,7 +229,7 @@ def legacy_process(provider, modulesdir, resources, datasources):
 
 def create_provider(provider, modulesdir):
     logging.debug("create_provider provider=%s modulesdir=%s", provider, modulesdir)
-    provider_path = os.path.join(modulesdir, "provider", "{}.py".format(provider))
+    provider_path = os.path.join(modulesdir, "provider", f"{provider}.py")
     with open(provider_path, "wt") as fp:
         fp.write(PROVIDER_TEMPLATE.render(provider=provider))
 
@@ -243,13 +243,13 @@ def get_sanitized_name(provider):
 
 
 def create_resources(provider, modulesdir, resources):
-    resource_path = os.path.join(modulesdir, "resource", "{}.py".format(provider))
+    resource_path = os.path.join(modulesdir, "resource", f"{provider}.py")
     with open(resource_path, "wt") as fp:
         fp.write(RESOURCES_TEMPLATE.render(provider=provider, resources=resources))
 
 
 def create_datasources(provider, modulesdir, datasources):
-    datasource_path = os.path.join(modulesdir, "data", "{}.py".format(provider))
+    datasource_path = os.path.join(modulesdir, "data", f"{provider}.py")
     with open(datasource_path, "wt") as fp:
         fp.write(
             DATASOURCES_TEMPLATE.render(provider=provider, datasources=datasources)
@@ -269,7 +269,7 @@ def process(entry, modulesdir):
     logging.info(repo_name)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        cmd = "git clone --depth=1 {} .".format(repository)
+        cmd = f"git clone --depth=1 {repository} ."
         result = subprocess.run(
             shlex.split(cmd),
             stdout=subprocess.PIPE,
@@ -330,7 +330,7 @@ def main():
         print("Script must be run from the tools/ folder", file=sys.stderr)
         sys.exit(1)
 
-    with open(INPUT, "rt") as fp:
+    with open(INPUT) as fp:
         entries = yaml.load(fp, Loader=yaml.SafeLoader)
         # entries is now a list of dictionaries: [{'name': NAME, 'repository': URL}, ...]
 


### PR DESCRIPTION
Fixes https://github.com/mjuenema/python-terrascript/issues/121.

Much already done in https://github.com/mjuenema/python-terrascript/commit/8448ecf7b5f5d01fd21734552082b28e619ef31c, this also upgrades Python syntax for 3.6+ using https://github.com/asottile/pyupgrade with `--py36-plus`.