### PR TITLE
Test Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 python:
 - '3.6'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.6'
 - '3.7'
 - '3.8'
+- '3.9-dev'
 env:
 - TERRAFORM=0.12.15
 - TERRAFORM=0.12.16


### PR DESCRIPTION
To make sure everything passes before its full release next month.

Also, `sudo:` no longer has any effect on Travis: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
