### PR TITLE
Use README.rst as description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 from os.path import join, dirname
 

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,14 @@ test_requirements = [
     for r in open(join(dirname(__file__), "test_requirements.txt")).readlines()
 ]
 
+with open("README.rst") as f:
+    long_description = f.read()
+
 setup(
     name="terrascript",
     version=__version__,
     description="Python module for creating Terraform configurations",
-    long_description="Terrascript provides a method of generating Terraform files, while harnessing all the features the Python language provides.",
+    long_description=long_description,
     author="Markus Juenemann",
     author_email="markus@juenemann.net",
     url="https://github.com/mjuenema/python-terrascript",


### PR DESCRIPTION
Fixes https://github.com/mjuenema/python-terrascript/issues/95.

Running `python setup.py --long-description` will show text it finds, and upload to TestPyPI to check it renders.

Also removes the fallback to legacy distutils, it's not recommended to be used and their plans underway to remove it from stdlib, see draft [PEP 632](https://www.python.org/dev/peps/pep-0632/).