### PR TITLE
Add direct link to FAQ

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,9 @@ original HCL format.
     }
 
 **Terrascript does not verify that the generated JSON code is a valid Terraform configuration.**
-**This is a deliberate design decision and is explained in the Frequently Asked Questions (FAQ)**
+**This is a deliberate design decision and is explained in the** `Frequently Asked Questions (FAQ) <https://python-terrascript.readthedocs.io/en/develop/faq.html>`_
+
+.. _Frequently Asked Questions (FAQ): https://python-terrascript.readthedocs.io/en/develop/faq.html
 
 Links
 ~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installing Terrascript
 ----------------------
 
-Terarscript is available from the Python Package Repository PyPi_ or
+Terrascript is available from the Python Package Repository PyPi_ or
 alternatively from its Github_ repository.
 
 .. _PyPi: https://pypi.org/project/terrascript/#history


### PR DESCRIPTION
I cannot both bold and link text in RST: https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible

But referencing the FAQ should have a direct link to where the FAQ is.