### PR TITLE
fixing wrong name, had used scaleway as template and missed this

### DIFF
--- a/terrascript/signalfx/__init__.py
+++ b/terrascript/signalfx/__init__.py
@@ -2,5 +2,5 @@
 import terrascript
 
 
-class scaleway(signalfx.Provider):
+class signalfx(signalfx.Provider):
     pass


### PR DESCRIPTION
missed this in my original PR, had based my work on the existing scaleway files and missed this part. 