### PR TITLE
Add install instructions directly on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,25 @@ superior to writing Terraform configurations by hand.
 
 Installing Terrascript
 ~~~~~~~~~~~~~~~~~~~~~~
+
+Terrascript is available from the Python Package Repository PyPi_ or
+alternatively from its Github_ repository.
+
+.. _PyPi: https://pypi.org/project/terrascript/#history
+.. _Github: https://github.com/mjuenema/python-terrascript
+
+
+Installing Terrascript from PyPi
+..................
+
 It is easiest to install Terrascript directly from the Python Package Index.
 
 .. code-block:: console
 
    $ python3 -m pip install terrascript
+
+Installing Terrascript from Github
+...................................
 
 Terrascript can also be installed from its Github_ repository.
 
@@ -58,13 +72,14 @@ Terrascript can also be installed from its Github_ repository.
    $ cd python-terrascript/
    $ git fetch
    $ git fetch --tags
-
+   
 The ``master`` branch should be identical to the version on PyPi.
 
 .. code-block:: console
 
    $ git checkout master
    $ python3 setup.py install
+
 The ``develop`` branch includes the latest changes but may not always
 in a stable state. Do not use the ``develop`` branch unless you want 
 to submit a merge request on github.

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,40 @@ superior to writing Terraform configurations by hand.
 
 * Control structures like ``if``/``else``, ``for``/``continue``/``break`` or ``try``/``except``/``finally``.
 * More string methods.
-* Python functions may be used as an alternative to Terraform Modules.
+* Python functions may be used as an alternative to Terraform_ Modules.
 * Access to the Python Standard Library and third-party packages.
 
-.. _Terraform: https://www.terraform.io 
+Installing Terrascript
+~~~~~~~~~~~~~~~~~~~~~~
+It is easiest to install Terrascript directly from the Python Package Index.
+
+.. code-block:: console
+
+   $ python3 -m pip install terrascript
+
+Terrascript can also be installed from its Github_ repository.
+
+.. code-block:: console
+
+   $ git clone https://github.com/mjuenema/python-terrascript.git
+   $ cd python-terrascript/
+   $ git fetch
+   $ git fetch --tags
+
+The ``master`` branch should be identical to the version on PyPi.
+
+.. code-block:: console
+
+   $ git checkout master
+   $ python3 setup.py install
+The ``develop`` branch includes the latest changes but may not always
+in a stable state. Do not use the ``develop`` branch unless you want 
+to submit a merge request on github.
+
+.. code-block:: console
+
+   $ git checkout develop
+   $ python3 setup.py install
 
 Compatibility
 ~~~~~~~~~~~~~
@@ -161,10 +191,12 @@ original HCL format.
 Links
 ~~~~~
 
+* Terraform_ for Terraform.
 * Documentation_ for Python-Terrascript.
 * Github_ page of Python-Terrascript.
 * `Terraform JSON`_ syntax.
 
+.. _Terraform: https://www.terraform.io 
 .. _Documentation: https://python-terrascript.readthedocs.io/en/develop/
 .. _Github: https://github.com/mjuenema/python-terrascript
 .. _`Terraform JSON`: https://www.terraform.io/docs/configuration/syntax-json.html

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ The ``master`` branch should be identical to the version on PyPi.
    $ python3 setup.py install
 
 The ``develop`` branch includes the latest changes but may not always
-in a stable state. Do not use the ``develop`` branch unless you want 
+be in a stable state. Do not use the ``develop`` branch unless you want 
 to submit a merge request on github.
 
 .. code-block:: console


### PR DESCRIPTION
It is common for the README to have the install instructions since the GitHub may be the first point of contact for a developer. I know for myself that having the commands here make it easy for me.