### PR TITLE
Should not use failing consul backend in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * Tool to generate provider bindings now accept provider to build
 ## Changed
 * All dot-files not explicitly included are now ignored by default
+* Backend tutorial code no longer uses (failing) consul backend
 * Script to generate providers:
   * Automatically sorts the list of providers alphabetically
   * Now try to guess the location of the required provider.go in the repository

--- a/docs/tutorials/backend1.py
+++ b/docs/tutorials/backend1.py
@@ -3,9 +3,7 @@ import terrascript
 config = terrascript.Terrascript()
 
 backend = terrascript.Backend(
-    "consul",
-    address="demo.consul.io",
-    scheme="https",
+    "local",
     path="example_app/terraform_state",
 )
 

--- a/docs/tutorials/backend1.tf
+++ b/docs/tutorials/backend1.tf
@@ -1,7 +1,5 @@
 terraform {
-  backend "consul" {
-    address = "demo.consul.io"
-    scheme  = "https"
+  backend "local" {
     path    = "example_app/terraform_state"
   }
 }

--- a/docs/tutorials/backend1/backend1.tf.json
+++ b/docs/tutorials/backend1/backend1.tf.json
@@ -1,9 +1,7 @@
 {
   "terraform": {
     "backend": {
-      "consul": {
-        "address": "demo.consul.io",
-        "scheme": "https",
+      "local": {
         "path": "example_app/terraform_state"
       }
     }


### PR DESCRIPTION
### Changed
* Backend tutorial code no longer uses (failing) consul backend